### PR TITLE
Fix missing VPC parent

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,12 @@ class Container extends pulumi.ComponentResource {
                     strategy: "None",
                 },
                 subnetSpecs: [{ type: "Isolated" }]
+            },
+            {
+                aliases: [{
+                    parent: pulumi.rootStackResource, // old parent
+                }],
+                parent: this, // new parent
             }
         );
     }


### PR DESCRIPTION
Add missing parent to `awsx.ec2.Vpc` instance, using `aliases` to prevent deletion & recreation of resources